### PR TITLE
Fix Fire Enchantment

### DIFF
--- a/Zenchantments/src/main/java/zedly/zenchantments/WatcherEnchant.java
+++ b/Zenchantments/src/main/java/zedly/zenchantments/WatcherEnchant.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.*;
@@ -52,7 +53,7 @@ public class WatcherEnchant implements Listener {
     private WatcherEnchant() {
     }
 
-    @EventHandler(ignoreCancelled = false)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
     public void onBlockBreak(BlockBreakEvent evt) {
         if (!evt.isCancelled() && !(evt instanceof BlockShredEvent) && evt.getBlock().getType() != AIR) {
             Player player = evt.getPlayer();
@@ -64,6 +65,7 @@ public class WatcherEnchant implements Listener {
         }
     }
 
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
     public void onBlockShred(BlockShredEvent evt) {
         if (!evt.isCancelled() && evt.getBlock().getType() != AIR) {
             Player player = evt.getPlayer();


### PR DESCRIPTION
Like the parent repository, this repository has, when I built it myself, a bug where the fire enchantment would not work as intended and would provide a way of creating infinite gold, iron and other materials without too much hassle. I thus propose some rather minor changes to make sure that the Events would not be passed when there is no need to, like if the even is cancelled by another Plugin. Due to this, this commit MAY have unintended side effect, which would however be very, very strange. It may also have some conflicts with logging and anti-cheat plugins, but these trade-offs are unarguably worth it. The fire enchantment is the only Enchantment known to be affected by this Pull Request.